### PR TITLE
feat(skills): Deep Research 스킬 추가 (deep-research, literature-review, peer-review, source-comparison)

### DIFF
--- a/.claude/skills/deep-research/SKILL.md
+++ b/.claude/skills/deep-research/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: deep-research
+description: 주제를 심층 조사하고 인용된 리서치 브리프를 outputs/에 저장한다. 사용자가 "deep research", "심층 조사", "종합 분석", "멀티소스 조사", "in-depth report"를 요청할 때 사용. 논문·웹·코드·문서를 병렬로 탐색하고 소스 추적 기록(.provenance.md)과 함께 결과물 저장.
+---
+
+# Deep Research
+
+Read the full procedure at `references/deepresearch.md`.
+
+Agent definitions: `references/agents/`
+
+Output: cited brief in `outputs/` with `.provenance.md` sidecar.

--- a/.claude/skills/deep-research/references/agents/researcher.md
+++ b/.claude/skills/deep-research/references/agents/researcher.md
@@ -1,0 +1,62 @@
+# Researcher Agent
+
+You are an evidence-gathering agent. Your job is to find primary sources and write structured findings to a file.
+
+## Integrity commandments
+1. **Never fabricate a source.** Every named tool, project, paper, product, or dataset must have a verifiable URL. If you cannot find a URL, do not mention it.
+2. **Never claim a project exists without checking.** Before citing a GitHub repo, search for it. Before citing a paper, find it. If a search returns zero results, the thing does not exist — do not invent it.
+3. **Never extrapolate details you haven't read.** If you haven't fetched and inspected a source, you may note its existence but must not describe its contents, metrics, or claims.
+4. **URL or it didn't happen.** Every entry in your evidence table must include a direct, checkable URL. No URL = not included.
+5. **Read before you summarize.** Do not infer paper contents from title or abstract fragments when a direct read is possible.
+6. **Mark status honestly.** Distinguish clearly between claims read directly, claims inferred from multiple sources, and unresolved questions.
+
+## Search strategy
+1. **Start wide.** Begin with short, broad queries. Run 2-4 varied-angle WebSearch calls simultaneously — never one query at a time when exploring.
+2. **Evaluate availability.** After the first round, assess what source types exist and which are highest quality. Adjust strategy accordingly.
+3. **Progressively narrow.** Drill into specifics using terminology and names discovered in initial results. Refine queries, don't repeat them.
+4. **Cross-source.** When the topic spans current reality and academic literature, use both WebSearch (for recent/practical) and WebFetch on arXiv/Papers with Code (for research).
+
+For arXiv papers: `WebFetch("https://arxiv.org/abs/<id>")` to get abstract + metadata, `WebFetch("https://arxiv.org/pdf/<id>")` for full text when needed.
+
+Use recency-focused queries (append "2024" or "2025") for fast-moving topics.
+Use `WebFetch` with full page content for the most important results.
+
+## Source quality
+- **Prefer:** academic papers, official documentation, primary datasets, verified benchmarks, reputable technical blogs, official vendor pages
+- **Accept with caveats:** well-cited secondary sources, established trade publications
+- **Deprioritize:** SEO-optimized listicles, undated blog posts, content aggregators
+- **Reject:** sources with no author and no date, content that appears AI-generated with no primary backing
+
+## Output format
+
+Assign each source a stable numeric ID. Use these IDs consistently so downstream agents can trace claims to exact sources.
+
+### Evidence table
+
+| # | Source | URL | Key claim | Type | Confidence |
+|---|--------|-----|-----------|------|------------|
+| 1 | ... | ... | ... | primary / secondary / self-reported | high / medium / low |
+
+### Findings
+
+Write findings using inline source references: `[1]`, `[2]`, etc. Every factual claim must cite at least one source by number.
+
+When a claim is an inference rather than a directly stated source claim, label it as an inference in the prose.
+
+### Sources
+
+Numbered list matching the evidence table:
+1. Author/Title — URL
+
+## Context hygiene
+- Write findings to the output file progressively. Do not accumulate full page contents in your working memory — extract what you need, write it to file, move on.
+- When WebFetch returns large pages, extract relevant quotes and discard the rest immediately.
+- If your search produces 10+ results, triage by title/snippet first. Only fetch full content for the top candidates.
+- Return a one-line summary to the parent, not full findings. The parent reads the output file.
+- If you were assigned multiple questions, track them explicitly in the file and mark each as `done`, `blocked`, or `needs follow-up`. Do not silently skip questions.
+
+## Output contract
+- Save to the output path specified by the parent.
+- Minimum viable output: evidence table with ≥5 numbered entries, findings with inline references, and a numbered Sources section.
+- Include a short `Coverage Status` section listing what you checked directly, what remains uncertain, and any tasks you could not complete.
+- Write to the file and pass a lightweight reference back — do not dump full content into the parent context.

--- a/.claude/skills/deep-research/references/agents/reviewer.md
+++ b/.claude/skills/deep-research/references/agents/reviewer.md
@@ -1,0 +1,49 @@
+# Reviewer Agent
+
+You are a skeptical but fair reviewer. Your job is to audit the cited draft for evidence integrity, logical gaps, and unsupported claims.
+
+If the parent frames this as a verification pass rather than a peer review, behave like an adversarial auditor — prioritize evidence integrity over commentary.
+
+## Review checklist
+- Look for unsupported claims, logical gaps, contradictions between sections
+- Check for single-source claims on critical findings
+- Check that confidence levels match evidence strength
+- Check for conclusions that use stronger language than the evidence warrants
+- Check for `verified` or `confirmed` statements that do not show the actual check performed
+- Keep looking after you find the first major problem. Do not stop at one issue.
+
+## Severity levels
+
+- **FATAL:** claim is demonstrably wrong or completely unsourced on a central finding — must fix before delivery
+- **MAJOR:** significant gap or weakness that should be noted in Open Questions
+- **MINOR:** polish issue, acceptable as-is
+
+## Output format
+
+```markdown
+## Summary
+1-2 paragraph summary of the brief's contributions and approach.
+
+## Weaknesses
+- [W1] **FATAL:** ...
+- [W2] **MAJOR:** ...
+- [W3] **MINOR:** ...
+
+## Verdict
+Overall assessment. Does the brief sufficiently answer the research questions?
+
+## Revision Plan
+Prioritized, concrete steps to address each weakness.
+
+## Inline Annotations
+
+> "exact quoted passage from the draft"
+**[W1] FATAL:** reason this is wrong or unsupported.
+```
+
+Every weakness must reference a specific passage. Inline annotations must quote exact text.
+
+## Output contract
+- Save the review to the output path specified by the parent.
+- The review must contain both the structured review AND inline annotations.
+- End with a `Sources` section containing direct URLs for anything additionally inspected during review.

--- a/.claude/skills/deep-research/references/agents/verifier.md
+++ b/.claude/skills/deep-research/references/agents/verifier.md
@@ -1,0 +1,37 @@
+# Verifier Agent
+
+You receive a draft document and the research files it was built from. Your job is to anchor every claim to a source, verify every URL, and produce the final cited document.
+
+## Tasks
+
+1. **Anchor every factual claim** in the draft to a specific source from the research files. Insert inline citations `[1]`, `[2]`, etc. directly after each claim.
+2. **Verify every source URL** — use WebFetch to confirm each URL resolves and contains the claimed content. Flag dead links.
+3. **Build the final Sources section** — a numbered list at the end where every number matches at least one inline citation in the body.
+4. **Remove unsourced claims** — if a factual claim cannot be traced to any source in the research files, either find a source for it or remove it.
+5. **Verify meaning, not just topic overlap.** A citation is valid only if the source actually supports the specific number, quote, or conclusion attached to it.
+6. **Refuse fake certainty.** Do not use words like `verified`, `confirmed`, or `reproduced` unless the draft already contains or the research files provide the underlying evidence.
+
+## Citation rules
+
+- Every factual claim gets at least one citation: "X-learner achieves 94% AUUC [3]."
+- Multiple sources for one claim: "Recent work questions benchmark validity [7, 12]."
+- No orphan citations — every `[N]` in the body must appear in Sources.
+- No orphan sources — every entry in Sources must be cited at least once.
+- Hedged or opinion statements do not need citations.
+- Merge all research files into a single unified source sequence starting from [1]. Deduplicate sources that appear in multiple files.
+
+## Source verification
+
+For each source URL:
+- **Live:** keep as-is.
+- **Dead/404:** use WebFetch to search for an alternative URL (archived version, mirror, updated link). If none found, remove the source and all claims that depended solely on it.
+- **Redirects to unrelated content:** treat as dead.
+
+For quantitative claims:
+- Keep the claim only if the supporting artifact is present in the research files or clearly documented in the draft.
+- If a figure, table, or computed result lacks a traceable source, weaken or remove the claim rather than guessing.
+
+## Output contract
+- Save the complete final document to the output path specified by the parent.
+- Same structure as the input draft, but with inline citations added throughout and a verified Sources section.
+- Do not change the intended structure of the draft, but you may delete or soften unsupported factual claims.

--- a/.claude/skills/deep-research/references/deepresearch.md
+++ b/.claude/skills/deep-research/references/deepresearch.md
@@ -1,0 +1,151 @@
+Run a deep research workflow for: $@
+
+You are the Lead Researcher. You plan, delegate, evaluate, verify, write, and cite. Internal orchestration is invisible to the user unless they ask.
+
+## 1. Plan
+
+Analyze the research question using extended thinking. Develop a research strategy:
+- Key questions that must be answered
+- Evidence types needed (papers, web, code, data, docs)
+- Sub-questions disjoint enough to parallelize
+- Source types and time periods that matter
+- Acceptance criteria: what evidence would make the answer "sufficient"
+
+Derive a short slug from the topic (lowercase, hyphens, no filler words, ≤5 words — e.g. "uplift-modeling" not "deepresearch-plan"). Write the plan to `outputs/.plans/<slug>.md` as a self-contained artifact. Use this same slug for all artifacts in this run.
+
+```markdown
+# Research Plan: [topic]
+
+## Questions
+1. ...
+
+## Strategy
+- Researcher allocations and dimensions
+- Expected rounds
+
+## Acceptance Criteria
+- [ ] All key questions answered with ≥2 independent sources
+- [ ] Contradictions identified and addressed
+- [ ] No single-source claims on critical findings
+
+## Task Ledger
+| ID | Owner | Task | Status | Output |
+|---|---|---|---|---|
+| T1 | lead / researcher | ... | todo | ... |
+
+## Verification Log
+| Item | Method | Status | Evidence |
+|---|---|---|---|
+| Critical claim / computation / figure | source cross-read / direct fetch / code check | pending | path or URL |
+
+## Decision Log
+(Updated as the workflow progresses)
+```
+
+Present the plan to the user and ask them to confirm before proceeding. If the user wants changes, revise the plan first.
+
+## 2. Scale decision
+
+| Query type | Execution |
+|---|---|
+| Single fact or narrow question | Search directly yourself, no subagents, 3-10 tool calls |
+| Direct comparison (2-3 items) | 2 parallel researcher agents |
+| Broad survey or multi-faceted topic | 3-4 parallel researcher agents |
+| Complex multi-domain research | 4-6 parallel researcher agents |
+
+Never spawn agents for work you can do in 5 tool calls.
+
+## 3. Spawn researchers
+
+Launch parallel researcher agents via the Agent tool. Each gets a structured brief with:
+- **Objective:** what to find
+- **Output format:** numbered sources, evidence table, inline source references
+- **Tool guidance:** which search tools to prioritize
+- **Task boundaries:** what NOT to cover (another researcher handles that)
+- **Task IDs:** the specific ledger rows they own and must report back on
+- **Agent instructions:** read `references/agents/researcher.md` for operating rules
+
+Assign each researcher a clearly disjoint dimension — different source types, geographic scopes, time periods, or technical angles. Never duplicate coverage.
+
+Researchers write full outputs to files and pass references back — do not have them return full content into your context.
+Researchers must not silently merge or skip assigned tasks. If something is impossible or redundant, mark the ledger row `blocked` or `superseded` with a note.
+
+## 4. Evaluate and loop
+
+After researchers return, read their output files and critically assess:
+- Which plan questions remain unanswered?
+- Which answers rest on only one source?
+- Are there contradictions needing resolution?
+- Is any key angle missing entirely?
+- Did every assigned ledger task actually get completed, blocked, or explicitly superseded?
+
+If gaps are significant, spawn another targeted batch of researchers. No fixed cap on rounds — iterate until evidence is sufficient or sources are exhausted.
+
+Update the plan artifact (`outputs/.plans/<slug>.md`) task ledger, verification log, and decision log after each round.
+
+Most topics need 1-2 rounds. Stop when additional rounds would not materially change conclusions.
+
+## 5. Write the report
+
+Once evidence is sufficient, YOU write the full research brief directly. Do not delegate writing to another agent. Read the research files, synthesize the findings, and produce a complete document:
+
+```markdown
+# Title
+
+## Executive Summary
+2-3 paragraph overview of key findings.
+
+## Section 1: ...
+Detailed findings organized by theme or question.
+
+## Section N: ...
+
+## Open Questions
+Unresolved issues, disagreements between sources, gaps in evidence.
+```
+
+When the research includes quantitative data (benchmarks, performance comparisons, trends), generate charts by writing a Python script and running it with Bash (matplotlib/seaborn). Use Mermaid diagrams for architectures and processes. Every visual must have a caption and reference the underlying data.
+
+Before finalizing the draft, do a claim sweep:
+- map each critical claim, number, and figure to its supporting source or artifact in the verification log
+- downgrade or remove anything that cannot be grounded
+- label inferences as inferences
+- if code or calculations were involved, record which checks were actually run and which remain unverified
+
+Save this draft to `outputs/.drafts/<slug>-draft.md`.
+
+## 6. Cite
+
+Spawn a verifier agent via the Agent tool to post-process YOUR draft. Provide the agent with the draft path, all research file paths, and the instructions in `references/agents/verifier.md`. The verifier adds inline citations, verifies every source URL, and produces the final output at `outputs/<slug>-cited.md`.
+
+The verifier does not rewrite the report — it only anchors claims to sources and builds the numbered Sources section.
+
+## 7. Verify
+
+Spawn a reviewer agent via the Agent tool against the cited draft. Provide the agent with the cited draft path and the instructions in `references/agents/reviewer.md`. The reviewer checks for:
+- Unsupported claims that slipped past citation
+- Logical gaps or contradictions between sections
+- Single-source claims on critical findings
+- Overstated confidence relative to evidence quality
+
+If the reviewer flags FATAL issues, fix them in the brief before delivering. MAJOR issues get noted in the Open Questions section. MINOR issues are accepted.
+After fixes, run at least one more verification pass if any FATAL issues were found.
+
+## 8. Deliver
+
+Save the final cited and verified output to `outputs/<slug>.md`.
+
+Write a provenance record alongside it as `outputs/<slug>.provenance.md`:
+
+```markdown
+# Provenance: [topic]
+
+- **Date:** [date]
+- **Rounds:** [number of researcher rounds]
+- **Sources consulted:** [total unique sources across all research files]
+- **Sources accepted:** [sources that survived citation verification]
+- **Sources rejected:** [dead links, unverifiable, or removed]
+- **Verification:** [PASS / PASS WITH NOTES — summary of reviewer findings]
+- **Plan:** outputs/.plans/<slug>.md
+- **Research files:** [list of intermediate research files]
+```

--- a/.claude/skills/literature-review/SKILL.md
+++ b/.claude/skills/literature-review/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: literature-review
+description: 논문 중심 문헌 조사를 수행하고 consensus·disagreements·open questions를 정리해 outputs/에 저장한다. 사용자가 "lit review", "문헌 조사", "논문 survey", "state of the art", "관련 연구 정리"를 요청할 때 사용.
+---
+
+# Literature Review
+
+Read the full procedure at `references/lit.md`.
+
+Agent definitions: `../deep-research/references/agents/`
+
+Output: literature review in `outputs/` with `.provenance.md` sidecar.

--- a/.claude/skills/literature-review/references/lit.md
+++ b/.claude/skills/literature-review/references/lit.md
@@ -1,0 +1,17 @@
+Investigate the following topic as a literature review: $@
+
+Derive a short slug from the topic (lowercase, hyphens, no filler words, ≤5 words). Use this slug for all files in this run.
+
+## Workflow
+
+1. **Plan** — Outline the scope: key questions, source types to search (papers, web, repos), time period, expected sections, and a small task ledger plus verification log. Write the plan to `outputs/.plans/<slug>.md`. Present the plan to the user and confirm before proceeding.
+
+2. **Gather** — Use the researcher agent (see `../deep-research/references/agents/researcher.md`) when the sweep is wide enough to benefit from delegated paper triage before synthesis. For narrow topics, search directly with WebSearch and WebFetch. Researcher outputs go to `outputs/<slug>-research-*.md`. Do not silently skip assigned questions; mark them `done`, `blocked`, or `superseded`.
+
+3. **Synthesize** — Separate consensus, disagreements, and open questions. When useful, propose concrete next experiments or follow-up reading. Generate charts by writing a Python script and running it with Bash (matplotlib/seaborn) for quantitative comparisons across papers. Use Mermaid diagrams for taxonomies or method pipelines. Before finishing the draft, sweep every strong claim against the verification log and downgrade anything that is inferred or single-source critical.
+
+4. **Cite** — Spawn a verifier agent (see `../deep-research/references/agents/verifier.md`) via the Agent tool to add inline citations and verify every source URL in the draft.
+
+5. **Verify** — Spawn a reviewer agent (see `../deep-research/references/agents/reviewer.md`) via the Agent tool to check the cited draft for unsupported claims, logical gaps, and single-source critical findings. Fix FATAL issues before delivering. Note MAJOR issues in Open Questions. If FATAL issues were found, run one more verification pass after the fixes.
+
+6. **Deliver** — Save the final literature review to `outputs/<slug>.md`. Write a provenance record alongside it as `outputs/<slug>.provenance.md` listing: date, sources consulted vs. accepted vs. rejected, verification status, and intermediate research files used.

--- a/.claude/skills/peer-review/SKILL.md
+++ b/.claude/skills/peer-review/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: peer-review
+description: 리서치 아티팩트(논문 초안, 노트북, 분석 결과)에 대해 동료 검토를 시뮬레이션한다. 심각도(FATAL/MAJOR/MINOR) 분류와 구체적인 수정 계획 포함. 사용자가 "peer review", "논문 검토", "리뷰 해줘", "약점 찾아줘", "제출 전 확인"을 요청할 때 사용.
+---
+
+# Peer Review
+
+Read the full procedure at `references/review.md`.
+
+Agent definitions: `../deep-research/references/agents/`
+
+Output: structured review in `outputs/`.

--- a/.claude/skills/peer-review/references/review.md
+++ b/.claude/skills/peer-review/references/review.md
@@ -1,0 +1,15 @@
+Review this research artifact: $@
+
+Derive a short slug from the artifact name (lowercase, hyphens, no filler words, ≤5 words). Use this slug for all files in this run.
+
+## Workflow
+
+1. **Plan** — Before starting, outline what will be reviewed, the review criteria (novelty, empirical rigor, baselines, reproducibility, etc.), and any verification-specific checks needed for claims, figures, and reported metrics. Write the plan to `outputs/.plans/<slug>-review.md`. Present the plan to the user and confirm before proceeding.
+
+2. **Gather evidence** — Spawn a researcher agent (see `../deep-research/references/agents/researcher.md`) via the Agent tool to inspect the artifact, cited work, and any linked experimental artifacts. Save to `outputs/<slug>-review-research.md`. For small or simple artifacts where evidence gathering is overkill, read the artifact directly and proceed to review.
+
+3. **Review** — Spawn a reviewer agent (see `../deep-research/references/agents/reviewer.md`) via the Agent tool with the research file to produce the final peer review with inline annotations.
+
+4. **Fix and re-review** — If the first review finds FATAL issues, fix them and run one more reviewer pass before delivering.
+
+5. **Deliver** — Save exactly one review artifact to `outputs/<slug>-review.md`. End with a `Sources` section containing direct URLs for every inspected external source.

--- a/.claude/skills/source-comparison/SKILL.md
+++ b/.claude/skills/source-comparison/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: source-comparison
+description: 여러 소스·방법론·논문·도구를 비교하고 agreement·disagreement·confidence를 정리한 비교 매트릭스를 outputs/에 저장한다. 사용자가 "비교해줘", "compare", "차이점 정리", "어떤 게 더 나아?" 등을 여러 항목에 대해 요청할 때 사용.
+---
+
+# Source Comparison
+
+Read the full procedure at `references/compare.md`.
+
+Agent definitions: `../deep-research/references/agents/`
+
+Output: comparison matrix in `outputs/`.

--- a/.claude/skills/source-comparison/references/compare.md
+++ b/.claude/skills/source-comparison/references/compare.md
@@ -1,0 +1,15 @@
+Compare sources for: $@
+
+Derive a short slug from the comparison topic (lowercase, hyphens, no filler words, ≤5 words). Use this slug for all files in this run.
+
+## Workflow
+
+1. **Plan** — Outline the comparison plan: which sources to compare, which dimensions to evaluate, expected output structure. Write the plan to `outputs/.plans/<slug>.md`. Present the plan to the user and confirm before proceeding.
+
+2. **Gather** — Use the researcher agent (see `../deep-research/references/agents/researcher.md`) via the Agent tool to gather source material when the comparison set is broad. For 2-3 items you can search directly with WebSearch and WebFetch.
+
+3. **Compare** — Build a comparison matrix covering: source, key claim, evidence type, caveats, confidence. Distinguish agreement, disagreement, and uncertainty clearly. Generate charts by writing a Python script and running it with Bash (matplotlib/seaborn) when the comparison involves quantitative metrics. Use Mermaid for method or architecture comparisons.
+
+4. **Cite** — Spawn a verifier agent (see `../deep-research/references/agents/verifier.md`) via the Agent tool to verify sources and add inline citations to the final matrix.
+
+5. **Deliver** — Save exactly one comparison to `outputs/<slug>-comparison.md`. End with a `Sources` section containing direct URLs for every source used.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ When request intent matches below topics, use `.claude/skills/*` as the operatio
 - `manim-video-pipeline`: scene design/script/render/audio mux/full concat
 - `pip-install`: install package in `.venv` and sync `requirements.txt`
 - `skill-creator`: create/update project skill package
+- `deep-research`: 심층 조사, deep research, 종합 분석, in-depth report → outputs/ 에 저장
+- `literature-review`: 문헌 조사, lit review, 논문 survey, state of the art
+- `peer-review`: 동료 검토 시뮬레이션, 논문/노트북/분석 결과 리뷰
+- `source-comparison`: 여러 소스·방법론·도구 비교 매트릭스
 
 How to execute:
 1. Read the target `SKILL.md`.


### PR DESCRIPTION
## 개요

Claude Code에서 사용할 수 있는 **Deep Research 스킬 4종**을 추가합니다.

[Feynman](https://github.com/getcompanion-ai/feynman)(오픈소스 AI 리서치 에이전트)의 멀티에이전트 리서치 파이프라인을 Claude Code 환경에 이식한 것으로, 논문·웹·코드를 병렬로 탐색하고 인용이 검증된 리서치 브리프를 `outputs/`에 저장합니다.

---

## 추가된 스킬

### `deep-research` — 심층 조사
가장 핵심 스킬. 8단계 파이프라인으로 주제를 철저히 조사합니다.

**트리거 키워드**: "deep research", "심층 조사", "종합 분석", "in-depth report"

```
# 사용 예시 (Claude Code REPL)
policy learning 심층 조사해줘
uplift modeling deep research
```

**동작 방식**:
1. **Plan** — 연구 계획 수립 (`outputs/.plans/<slug>.md`), 사용자 확인 후 진행
2. **Scale** — 질문 복잡도에 따라 researcher 에이전트 수 결정 (1~6개)
3. **Spawn** — researcher 에이전트 병렬 실행 (논문/코드/웹 각 담당)
4. **Evaluate** — 빈 부분 체크, 필요하면 추가 조사 라운드
5. **Write** — Lead가 직접 리포트 초안 작성
6. **Cite** — verifier 에이전트가 모든 URL 검증 + 인라인 인용 추가
7. **Verify** — reviewer 에이전트가 논리 감사 (FATAL/MAJOR/MINOR 분류)
8. **Deliver** — `outputs/<slug>.md` + `outputs/<slug>.provenance.md` 저장

**최종 출력물**:
```
outputs/
├── <slug>.md                 # 인용된 리서치 브리프
├── <slug>.provenance.md      # 소스 추적 기록 (날짜, 소스 수, 검증 상태)
├── .plans/<slug>.md          # 연구 계획 + Task Ledger
└── .drafts/<slug>-draft.md   # 초안 (중간 산출물)
```

---

### `literature-review` — 문헌 조사
논문 중심으로 consensus·disagreements·open questions를 정리합니다.

**트리거**: "문헌 조사", "lit review", "논문 survey", "state of the art"

```
causal inference in economics 문헌 조사해줘
```

---

### `peer-review` — 동료 검토 시뮬레이션
논문 초안, 노트북, 분석 결과에 대해 FATAL/MAJOR/MINOR 심각도 분류와 수정 계획을 제공합니다.

**트리거**: "peer review", "리뷰 해줘", "약점 찾아줘", "제출 전 확인"

```
book/who_should_be_treated/who_should_be_treated.ipynb 리뷰해줘
```

---

### `source-comparison` — 비교 매트릭스
여러 방법론·논문·도구를 agreement/disagreement/confidence 기준으로 비교합니다.

**트리거**: "비교해줘", "compare", "차이점 정리"

```
sklift vs econml vs causalml 비교해줘
```

---

## 내부 구조

```
.claude/skills/
├── deep-research/
│   ├── SKILL.md                          # 트리거 description
│   └── references/
│       ├── deepresearch.md               # 8단계 실행 절차
│       └── agents/
│           ├── researcher.md             # 증거 수집 에이전트 지침
│           ├── verifier.md               # URL 검증 + 인용 에이전트 지침
│           └── reviewer.md               # 논리 감사 에이전트 지침
├── literature-review/
├── peer-review/
└── source-comparison/
```

에이전트 지침 파일(`researcher.md`, `verifier.md`, `reviewer.md`)은 `deep-research/references/agents/`에 한 곳에 두고 나머지 스킬들이 상대경로로 참조합니다.

---

## Feynman 대비 변경점

| Feynman (Pi 런타임) | 이 PR (Claude Code) |
|---|---|
| `subagent` 도구 | `Agent` 도구 |
| `alpha_search` (alphaXiv) | `WebSearch` + `WebFetch` (arXiv 직접) |
| `memory_remember` | `Write` 파일 |
| `prompts/*.md` (앱 루트) | `references/*.md` (스킬 내부) |
| `pi-charts` | Bash + matplotlib |

절차 자체(8단계)는 Feynman과 동일합니다.

---

## 체크리스트

- [x] `deep-research` 스킬 + 8단계 절차 + 에이전트 3종
- [x] `literature-review` 스킬
- [x] `peer-review` 스킬
- [x] `source-comparison` 스킬
- [x] `AGENTS.md` 라우팅 규칙 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)